### PR TITLE
Default role removal after level change

### DIFF
--- a/pmpro-roles.php
+++ b/pmpro-roles.php
@@ -234,6 +234,12 @@ class PMPRO_Roles {
 			$new_roles = array();
 			$old_roles = array();
 	
+			// Add default role to $old_roles if it is already one of the user roles
+			$default_role = apply_filters( 'pmpro_roles_downgraded_role', get_option( 'default_role' ) );
+			if ( in_array( $default_role, $user->roles ) ) {
+                		$old_roles = array( $default_role );
+			}
+
 			// Build an array of all roles assigned to the user's old membership levels.
 			foreach ( $old_levels as $old_level ) {
 				$old_level_roles = self::get_roles_for_level( $old_level->id );
@@ -266,12 +272,6 @@ class PMPRO_Roles {
 			// Remove roles from user.
 			foreach ( $remove_roles as $remove_role ) {
 				$user->remove_role( $remove_role );
-			}
-
-			// Handle case where role can be "simplified" to a single role.
-			$default_role = apply_filters( 'pmpro_roles_downgraded_role', get_option( 'default_role' ) );
-			if ( in_array( $default_role, $user->roles, true ) && count( $user->roles ) == 2 ) {
-				$user->remove_role( $default_role );
 			}
 
 			// Handle case where user has no role.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

These changes adds the default role to the $old_roles array instead of using `$user->remove_role( $default_role );` further down.

This resolves three issues:

(Issue 1)
Setting up the default role to be removed when the user has two roles (and the default role is one of the two), has the unintended effect of removing the default role if the user assigns the default role plus one other role to a level.

(Issue 2)
Default role fails to be removed when the user starts off with no membership levels at all, and the user's new membership level has more than one role (and default role is not one of them).

(Issue 3)
Default role fails to be removed when it is not an assigned role in any of the user's old membership levels, and the user's new membership level has more than one role (and default role is not one of them).

### How to test the changes in this Pull Request:

1. Assign one role (not default role) to a membership level
2. Sign up a new member to that level (notice the default role is removed)
3. Assign default role plus one other role to a membership level
4. Sign up a new member to that level (notice the default role is removed)
5. Assign two roles (not default role) to a membership level
6. Sign up a new member to that level (notice the default role is NOT removed)
7. Apply changes in this pull request and try 1-6 again
8. default role would NOT be removed when default role plus one other role is assigned to a membership level
9. default role would be removed when two roles (neither role default) are assigned to a membership level

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

BUG FIX: Default role is no longer removed when default role plus one other role is assigned to a membership level. When two roles or more are assigned to a membership level, and none of those are default roles, the default role would no longer fail to be removed.